### PR TITLE
Fix title for 2022 edition

### DIFF
--- a/templates/2022/header.inc
+++ b/templates/2022/header.inc
@@ -9,9 +9,9 @@
 	<head>
 		<title>
 %if title:
-	PLISS 2021: ${title}
+	PLISS 2022: ${title}
 %else:
-    PLISS 2021
+    PLISS 2022
 %endif
         </title>
 		<meta charset="utf-8" />


### PR DESCRIPTION
I noticed that the 2022 edition pages said 2021 in page title, so hopefully this will fix it up.