### PR TITLE
Make it more obvious that registration is open

### DIFF
--- a/templates/2022/index.html
+++ b/templates/2022/index.html
@@ -46,8 +46,11 @@
 					<div class="container">
                         <header class="major">
                         <h2>Registration</h2>
-                        <p>The registration for PLISS 2022 will open soon.</p>
+                        <p>The registration for PLISS 2022 is now open.</p>
                         </header>
+                        <ul class="actions">
+							<li><a href="registration.html" class="button special big">Click here to register</a></li>
+						</ul>
 					</div>
 				</section>
 


### PR DESCRIPTION
This updates the big space at the bottom of main page to link to registration.

The indentation looks somewhat chaotic because of a mix of tabs vs. spaces... I just copied it from the previous year. 😇 